### PR TITLE
fix container image paths when testing on windows

### DIFF
--- a/manifesttestutils/resource_builder.go
+++ b/manifesttestutils/resource_builder.go
@@ -397,7 +397,7 @@ func GetAppLabels(appName, category string) map[string]string {
 func GetContainerSpec(registry, name, tag string, envVars ...v1.EnvVar) ContainerSpec {
 	return ContainerSpec{
 		Name:    name,
-		Image:   fmt.Sprintf("%s:%s", filepath.Join(registry, name), tag),
+		Image:   fmt.Sprintf("%s:%s", filepath.ToSlash(filepath.Join(registry, name)), tag),
 		EnvVars: envVars,
 	}
 }


### PR DESCRIPTION
This fixes an issue with container image paths being rendered incorrectly when testing on windows

`quay.io\\solo-io\\access-logger:1.9.0-beta6-dirty` should be `quay.io/solo-io/access-logger:1.9.0-beta6-dirty`