### PR TITLE
Support Ephemeral Containers in Kube 1.22

### DIFF
--- a/testutils/helper/testrunner.go
+++ b/testutils/helper/testrunner.go
@@ -30,8 +30,6 @@ const (
 <li><a href="mnt/">mnt/</a>
 <li><a href="opt/">opt/</a>
 <li><a href="proc/">proc/</a>
-<li><a href="product_name">product_name</a>
-<li><a href="product_uuid">product_uuid</a>
 <li><a href="root/">root/</a>
 <li><a href="root.crt">root.crt</a>
 <li><a href="run/">run/</a>
@@ -46,7 +44,6 @@ const (
 </body>
 </html>`
 )
-
 
 func NewTestRunner(namespace string) (*testRunner, error) {
 	testContainer, err := newTestContainer(namespace, defaultTestRunnerImage, TestrunnerName, TestRunnerPort)

--- a/testutils/helper/testrunner.go
+++ b/testutils/helper/testrunner.go
@@ -30,6 +30,8 @@ const (
 <li><a href="mnt/">mnt/</a>
 <li><a href="opt/">opt/</a>
 <li><a href="proc/">proc/</a>
+<li><a href="product_name">product_name</a>
+<li><a href="product_uuid">product_uuid</a>
 <li><a href="root/">root/</a>
 <li><a href="root.crt">root.crt</a>
 <li><a href="run/">run/</a>
@@ -44,6 +46,7 @@ const (
 </body>
 </html>`
 )
+
 
 func NewTestRunner(namespace string) (*testRunner, error) {
 	testContainer, err := newTestContainer(namespace, defaultTestRunnerImage, TestrunnerName, TestRunnerPort)

--- a/testutils/kube/curl.go
+++ b/testutils/kube/curl.go
@@ -15,16 +15,38 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func CurlWithEphemeralPod(ctx context.Context, logger io.Writer, kubecontext, fromns, frompod string, args ...string) string {
-	createargs := []string{"alpha", "debug", "--quiet",
+func CurlWithEphemeralPod(ctx context.Context, logger io.Writer, kubeContext, fromNs, fromPod string, args ...string) string {
+	createArgs := []string{
+		"debug",
+		"--quiet",
 		"--image=curlimages/curl@sha256:aa45e9d93122a3cfdf8d7de272e2798ea63733eeee6d06bd2ee4f2f8c4027d7c",
-		"--container=curl", frompod, "-n", fromns, "--", "sleep", "10h"}
+		"--container=curl",
+		"--image-pull-policy=IfNotPresent",
+		fromPod,
+		"-n",
+		fromNs,
+		"--",
+		"sleep",
+		"10h",
+	}
 	// Execute curl commands from the same pod each time to avoid creating a burdensome number of ephemeral pods.
 	// create the curl pod; we do this every time and it will only work the first time, so ignore failures
-	executeNoFail(ctx, logger, kubecontext, createargs...)
-	args = append([]string{"exec",
-		"--container=curl", frompod, "-n", fromns, "--", "curl", "--connect-timeout", "1", "--max-time", "5"}, args...)
-	return execute(ctx, logger, kubecontext, args...)
+	_, _ = executeNoFail(ctx, logger, kubeContext, createArgs...)
+
+	args = append([]string{
+		"exec",
+		"--container=curl",
+		fromPod,
+		"-n",
+		fromNs,
+		"--",
+		"curl",
+		"--connect-timeout",
+		"1",
+		"--max-time",
+		"5",
+	}, args...)
+	return execute(ctx, logger, kubeContext, args...)
 }
 
 // labelSelector is a string map e.g. gloo=gateway-proxy


### PR DESCRIPTION
# Description
Support Ephemeral Containers in Kube 1.22


# Context
For example, in Gloo Edge, when we upgrade kubernetes (https://github.com/solo-io/gloo/pull/5693) we faced the following error:
```
clusters: Error from server (BadRequest): container curl is not valid for pod gateway-proxy-755bb9b94f-nk6xg
```

This happened because the command used to generated the ephemeral container was failing. 

https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/#api-changes-and-improvements-for-ephemeral-containers