### PR TITLE
Move check for test directories

### DIFF
--- a/changelog/v0.1.3/directory_check.yaml
+++ b/changelog/v0.1.3/directory_check.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/4191
+    resolvesIssue: false
+    description: Move check for _test and _build directories so that it only occurs when installing from locally built versions.

--- a/testutils/helper/install.go
+++ b/testutils/helper/install.go
@@ -81,12 +81,12 @@ func NewSoloTestHelper(configFunc TestConfigFunc) (*SoloTestHelper, error) {
 	if configFunc != nil {
 		testConfig = configFunc(defaults)
 	}
-	if err := validateConfig(testConfig); err != nil {
-		return nil, errors.Wrapf(err, "test config validation failed")
-	}
 
 	// Get chart version
 	if testConfig.ReleasedVersion == "" {
+		if err := validateConfig(testConfig); err != nil {
+			return nil, errors.Wrapf(err, "test config validation failed")
+		}
 		version, err := getChartVersion(testConfig)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting Helm chart version")


### PR DESCRIPTION
When we install gloo from a release, we don't need assets in the _test and _build directories and the check for the existence of those directories was failing in the nightly runs.