### PR TITLE
kubeutils/annotations: Mimick skv2's approach to store clustername in  annotations for k8s 1.24+

### DIFF
--- a/changelog/v0.1.4/clustername-as-annotations.yaml
+++ b/changelog/v0.1.4/clustername-as-annotations.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/solo-projects/issues/7071
-    resolvesIssue: false
-    description: Clustername override

--- a/changelog/v0.1.4/clustername-as-annotations.yaml
+++ b/changelog/v0.1.4/clustername-as-annotations.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7071
+    resolvesIssue: false
+    description: Clustername override

--- a/changelog/v0.1.5/clustername-as-annotations.yaml
+++ b/changelog/v0.1.5/clustername-as-annotations.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7071
+    resolvesIssue: false
+    description: Clustername override

--- a/installutils/kuberesource/unstructured.go
+++ b/installutils/kuberesource/unstructured.go
@@ -9,6 +9,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/contextutils"
+	"github.com/solo-io/k8s-utils/kubeutils"
 
 	"github.com/pkg/errors"
 	"k8s.io/api/admissionregistration/v1beta1"
@@ -282,6 +283,6 @@ func zeroGeneratedValues(obj *unstructured.Unstructured) {
 	obj.SetDeletionGracePeriodSeconds(nil)
 	obj.SetFinalizers(nil)
 	obj.SetOwnerReferences(nil)
-	obj.SetClusterName("")
+	kubeutils.SetClusterName(obj, "")
 	delete(obj.Object, "status")
 }

--- a/installutils/kuberesource/unstructured_test.go
+++ b/installutils/kuberesource/unstructured_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/solo-io/k8s-utils/kubeutils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -93,7 +94,7 @@ var _ = Describe("Unstructured", func() {
 			res2.SetCreationTimestamp(v1.Time{Time: time.Now()})
 			res2.SetDeletionTimestamp(&v1.Time{Time: time.Now()})
 			res2.SetDeletionGracePeriodSeconds(proto.Int64(64))
-			res2.SetClusterName("abcd")
+			kubeutils.SetClusterName(res2, "abcd")
 			res2.Object["status"] = "asdf"
 			Expect(Match(context.Background(), res1, res2)).To(BeTrue())
 			res2.Object["anyotherfield"] = "asdf"

--- a/kubeutils/annotations.go
+++ b/kubeutils/annotations.go
@@ -1,0 +1,29 @@
+package kubeutils
+
+// SoloClusterAnnotation was originally implemented in solo-kitv2's ezkube package
+// It allows for easy mimicking of the old clustername field present in
+// k8s prior to 1.24. It is stored here to make future changes easier and not
+// require multi package switches as if any of the dependant packages are out of
+// sync on this field it can cause hard to diagnose issues.
+const SoloClusterAnnotation = "cluster.solo.io/cluster"
+
+type hasAnnotations interface {
+	SetAnnotations(map[string]string)
+	GetAnnotations() map[string]string
+}
+
+// GetClusterName from within the annotations
+func GetClusterName(ha hasAnnotations) string {
+	return ha.GetAnnotations()[SoloClusterAnnotation]
+}
+
+// SetClusterName on the retrieved annotations
+// Set annotations which while slow is correct.
+func SetClusterName(ha hasAnnotations, clusterName string) {
+	anno := ha.GetAnnotations()
+	if anno == nil {
+		anno = map[string]string{}
+	}
+	anno[SoloClusterAnnotation] = clusterName
+	ha.SetAnnotations(anno)
+}


### PR DESCRIPTION
Annotations are used now that clustername is deprecated