### PR TITLE
add option to curl opts to limit log pollution

### DIFF
--- a/changelog/v0.2.1/add-logresponses-to-testhelper-curl-opts.yaml
+++ b/changelog/v0.2.1/add-logresponses-to-testhelper-curl-opts.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Added LogResponses as an option to curl ops - in order to log out response you can set this value to true. Reduces log polution

--- a/changelog/v0.2.1/add-logresponses-to-testhelper-curl-opts.yaml
+++ b/changelog/v0.2.1/add-logresponses-to-testhelper-curl-opts.yaml
@@ -1,3 +1,4 @@
 changelog:
   - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/4362
     description: Added LogResponses as an option to curl ops - in order to log out response you can set this value to true. Reduces log polution

--- a/testutils/helper/curl.go
+++ b/testutils/helper/curl.go
@@ -25,6 +25,7 @@ type CurlOpts struct {
 	ReturnHeaders     bool
 	ConnectionTimeout int
 	Verbose           bool
+	LogResponses      bool
 	// WithoutStats sets the -s flag to prevent download stats from printing
 	WithoutStats bool
 	// Optional SNI name to resolve domain to when sending request
@@ -112,11 +113,11 @@ func (t *testContainer) CurlEventuallyShouldRespond(opts CurlOpts, substr string
 		default:
 			break
 		case <-tick:
-			if opts.Verbose {
+			if opts.LogResponses {
 				log.GreyPrintf("running: %v\nwant %v\nhave: %s", opts, substr, res)
 			}
 		}
-		if strings.Contains(res, substr) {
+		if strings.Contains(res, substr) && opts.LogResponses {
 			log.GreyPrintf("success: %v", res)
 		}
 		return res

--- a/testutils/helper/test_container_test.go
+++ b/testutils/helper/test_container_test.go
@@ -41,7 +41,6 @@ var _ = Describe("test container tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 	Context("test runner", func() {
-
 		var (
 			testRunner *testRunner
 		)
@@ -52,12 +51,10 @@ var _ = Describe("test container tests", func() {
 			err = testRunner.Deploy(time.Minute * 2)
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 		AfterEach(func() {
 			err := testRunner.Terminate()
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 		It("can install and uninstall the testrunner", func() {
 			// responseString := fmt.Sprintf(`"%s":"%s.%s.svc.cluster.local:%v"`,
 			// 	linkerd.HeaderKey, helper.HttpEchoName, testHelper.InstallNamespace, helper.HttpEchoPort)
@@ -72,11 +69,9 @@ var _ = Describe("test container tests", func() {
 				ConnectionTimeout: 10,
 			}, SimpleHttpResponse, 1, 120*time.Second)
 		})
-
 	})
 
 	Context("http ehco", func() {
-
 		var (
 			httpEcho *echoPod
 		)
@@ -87,7 +82,6 @@ var _ = Describe("test container tests", func() {
 			err = httpEcho.deploy(time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 		AfterEach(func() {
 			err := httpEcho.Terminate()
 			Expect(err).NotTo(HaveOccurred())
@@ -104,12 +98,12 @@ var _ = Describe("test container tests", func() {
 				Service:           HttpEchoName,
 				Port:              HttpEchoPort,
 				ConnectionTimeout: 10,
+				Verbose:           true,
 			}, responseString, 1, 120*time.Second)
 		})
 	})
 
 	Context("tcp ehco", func() {
-
 		var (
 			tcpEcho *echoPod
 		)
@@ -120,7 +114,6 @@ var _ = Describe("test container tests", func() {
 			err = tcpEcho.deploy(time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 		AfterEach(func() {
 			err := tcpEcho.Terminate()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Adding LogResponses option to curl opts 

Currently, if we set responses to verbose we assume that also means you want to log every response. This can lead to hard to parse logs that are mostly returned responses rather than a focus on what failed 
BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/4362