### PR TITLE
Fix yaml separator

### DIFF
--- a/changelog/v0.5.1/fix-yaml-separator.yaml
+++ b/changelog/v0.5.1/fix-yaml-separator.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8648
+    resolvesIssue: false
+    description: Add newline to end of yaml separator to better detect properly-formatted helm manifests.

--- a/installutils/helmchart/manifests.go
+++ b/installutils/helmchart/manifests.go
@@ -73,7 +73,7 @@ func (m Manifests) CombinedString() string {
 	return buf.String()
 }
 
-var yamlSeparator = regexp.MustCompile("\n---")
+var yamlSeparator = regexp.MustCompile("\n---\n")
 
 func (m Manifests) ResourceList() (kuberesource.UnstructuredResources, error) {
 	snippets := yamlSeparator.Split(m.CombinedString(), -1)

--- a/installutils/helmchart/manifests.go
+++ b/installutils/helmchart/manifests.go
@@ -73,10 +73,10 @@ func (m Manifests) CombinedString() string {
 	return buf.String()
 }
 
-var yamlSeparator = regexp.MustCompile("\n---\n")
+var YamlSeparator = regexp.MustCompile("\n---\n")
 
 func (m Manifests) ResourceList() (kuberesource.UnstructuredResources, error) {
-	snippets := yamlSeparator.Split(m.CombinedString(), -1)
+	snippets := YamlSeparator.Split(m.CombinedString(), -1)
 
 	var resources kuberesource.UnstructuredResources
 	for _, objectYaml := range snippets {

--- a/manifesttestutils/util.go
+++ b/manifesttestutils/util.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
-	"regexp"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/k8s-utils/installutils/helmchart"
@@ -313,17 +311,13 @@ func mustReadManifest(relativePathToManifest string) string {
 	return string(bytes)
 }
 
-var (
-	yamlSeparator = regexp.MustCompile("\n---\n")
-)
-
 func mustGetResourcesFromFile(relativePathToManifest string) kuberesource.UnstructuredResources {
 	manifest := mustReadManifest(relativePathToManifest)
 	return mustGetResourcesFromYaml(manifest)
 }
 
 func mustGetResourcesFromYaml(manifest string) kuberesource.UnstructuredResources {
-	snippets := yamlSeparator.Split(manifest, -1)
+	snippets := helmchart.YamlSeparator.Split(manifest, -1)
 
 	var resources kuberesource.UnstructuredResources
 	for _, objectYaml := range snippets {

--- a/manifesttestutils/util.go
+++ b/manifesttestutils/util.go
@@ -314,7 +314,7 @@ func mustReadManifest(relativePathToManifest string) string {
 }
 
 var (
-	yamlSeparator = regexp.MustCompile("\n---")
+	yamlSeparator = regexp.MustCompile("\n---\n")
 )
 
 func mustGetResourcesFromFile(relativePathToManifest string) kuberesource.UnstructuredResources {


### PR DESCRIPTION
Add newline to end of yaml separator to better detect properly-formatted helm manifests.