### PR TITLE
ConvertUnstructured cronjob

### DIFF
--- a/changelog/v0.7.2/structured-cron-job.yaml
+++ b/changelog/v0.7.2/structured-cron-job.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add "CronJob" to the list of unstructured resources that can be converted to structured.

--- a/installutils/kuberesource/unstructured.go
+++ b/installutils/kuberesource/unstructured.go
@@ -166,6 +166,8 @@ func ConvertUnstructured(res *unstructured.Unstructured) (runtime.Object, error)
 		obj = &rbac.RoleBinding{TypeMeta: typeMeta}
 	case "Job":
 		obj = &batch.Job{TypeMeta: typeMeta}
+	case "CronJob":
+		obj = &batch.CronJob{TypeMeta: typeMeta}
 	case "ConfigMap":
 		obj = &core.ConfigMap{TypeMeta: typeMeta}
 	case "Service":


### PR DESCRIPTION
Add "CronJob" to the list of unstructured resources that can be converted to a runtime object